### PR TITLE
Implementation of simple clustering analysis on points

### DIFF
--- a/feature-extraction/cluster_points.py
+++ b/feature-extraction/cluster_points.py
@@ -1,0 +1,18 @@
+from sklearn.cluster import KMeans
+from sklearn.metrics import silhouette_score
+
+clusters_range = range(2, 21, 2) # Search for clusters in range [2, 20], giving a step of 2
+
+def number_clusters(X):
+    best_n, best_silhouette = 1, -1.0
+    for n_cluster in clusters_range:
+        clusterer = KMeans(n_clusters=n_cluster, random_state=10)
+        cluster_labels = clusterer.fit_predict(X)
+        silhouette_avg = silhouette_score(X, cluster_labels)
+        # print("Para cluster = ", n_cluster, " Valor= ", silhouette_avg)
+
+        if (silhouette_avg > best_silhouette):
+            best_silhouette = silhouette_avg
+            best_n = n_cluster
+    
+    return best_n, len(X)/best_n

--- a/feature-extraction/extract_features.py
+++ b/feature-extraction/extract_features.py
@@ -6,6 +6,7 @@ import math
 import os
 import numpy as np
 import graham_scan
+import cluster_points
 
 def distanceTwoTasks(task1, task2):
     dx = task1.x - task2.x
@@ -58,7 +59,8 @@ features_list = ["instance", "avgDistance", "minDistance", "maxDistance", "stdDe
                     "depotTask-x", "depotTask-y", "N_Tasks", "convex_hull_points", "convex_hull_length", 
                     "points_inside_hull", "convex_hull_area", "average_timespan", "std_deviation_timespan", 
                     "highest_last_time", "highest_early_time", "lowest_last_time", "lowest_early_time",
-                    "Q1_early_time", "Q2_early_time", "Q3_early_time", "Q1_late_time", "Q2_late_time", "Q3_late_time"]
+                    "Q1_early_time", "Q2_early_time", "Q3_early_time", "Q1_late_time", "Q2_late_time", "Q3_late_time",
+                    "n_clusters", "avg_clusterSize"]
 
 with open("features.csv", "w", newline='') as features_file:
     wr = csv.writer(features_file, dialect='excel')
@@ -246,6 +248,17 @@ for inst_line in inst_file_lines:
         features_list.append(np.quantile(late_time, q=0.50)) # same as median
         features_list.append(np.quantile(late_time, q=0.75))
 
+        # Clusters of data
+        if (file_name.lower().startswith("lc") or file_name.lower().startswith("lrc")): # currently working only for li&lim
+            xy_data = [[float(pickupTasks[i].x), float(pickupTasks[i].y)] for i in pickupIDs] + [[float(deliveryTasks[i].x), float(deliveryTasks[i].y)] for i in deliveryIDs]
+            xy_data = np.array(xy_data)
+            n_clusters, avg_size_cluster = cluster_points.number_clusters(xy_data)
+            features_list.append(n_clusters)
+            features_list.append(avg_size_cluster)
+        else:
+            features_list.append(1)
+            features_list.append(len(pickupIDs)+len(deliveryIDs))
+        
         # Insertion of the features in the CSV file
 
         with open("features.csv", "a", newline='') as features_file:


### PR DESCRIPTION
To the data that are clustered ('c', 'rc') tries to find a clustering number to the instance. The current implementation is valid to li&lim only, as it looks at the filename to decide if runs the algorithm. For Carlo's instances modification will be needed.

Followed [these implementation](https://scikit-learn.org/stable/auto_examples/cluster/plot_kmeans_silhouette_analysis.html) from sklearn, that applies the [Silhouette](https://en.wikipedia.org/wiki/Silhouette_(clustering)) method.
This implementation searches of clusters of size in a range [2, 20], using a step of 2, so the process is not so expensive (but still takes longer time).

If it is not clustered, returns 1 as cluster number and the avgSize as the total number of points.